### PR TITLE
[Bugfix] 修复对于某些基于 OneBot 协议的插件的输入处理

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,7 +129,8 @@ Muice-Chatbot     <- 主路径
     "known_topic_probability": 0.003,
     "time_topic_probability": 0.75,
     "port":21050,
-    "bot_qq_id":123456789
+    "bot_qq_id":123456789,
+    "Is_OneBot_Plugin": false,
 }
 ```
 
@@ -152,6 +153,8 @@ Muice-Chatbot     <- 主路径
 `port`: 反向WebSocket服务的端口号，默认`21050`。
 
 `bot_qq_id`: 机器人的QQ号。
+
+`Is_OneBot_Plugin`: 当抛出错误`data['message'] 不是列表`时将此选项设置为true。
 
 # 使用🎉
 

--- a/Readme.md
+++ b/Readme.md
@@ -131,6 +131,7 @@ Muice-Chatbot     <- 主路径
     "port":21050,
     "bot_qq_id":123456789,
     "Is_OneBot_Plugin": false,
+    "Group_Message_Reply_Only_To_Trusted": true
 }
 ```
 
@@ -155,6 +156,8 @@ Muice-Chatbot     <- 主路径
 `bot_qq_id`: 机器人的QQ号。
 
 `Is_OneBot_Plugin`: 当抛出错误`data['message'] 不是列表`时将此选项设置为true。
+
+`Group_Message_Reply_Only_To_Trusted`: 是否仅对信任的群聊回复。
 
 # 使用🎉
 

--- a/Readme.md
+++ b/Readme.md
@@ -157,7 +157,7 @@ Muice-Chatbot     <- 主路径
 
 `Is_OneBot_Plugin`: 当抛出错误`data['message'] 不是列表`时将此选项设置为true。
 
-`Group_Message_Reply_Only_To_Trusted`: 是否仅对信任的群聊回复。
+`Group_Message_Reply_Only_To_Trusted`: 是否仅对信任的qq回复。
 
 # 使用🎉
 

--- a/configs.json
+++ b/configs.json
@@ -17,8 +17,8 @@
     "Group_Message_Reply": true,
     "Trust_QQ_Group_list": [
         114514,
-        191918,
+        191918
     ],
     "Is_OneBot_Plugin": false,
-    "Group_Reply_Only_to_Trusted": true
+    "Group_Message_Reply_Only_To_Trusted": true
 }

--- a/configs.json
+++ b/configs.json
@@ -19,5 +19,6 @@
         114514,
         191918,
     ],
+    "Is_OneBot_Plugin": false,
     "Group_Reply_Only_to_Trusted": true
 }


### PR DESCRIPTION
# 案件回放

部分基于 OneBot 协议的插件（如[onebot-kotlin](https://github.com/yyuueexxiinngg/onebot-kotlin)）输出的`data['message']`为字符串，这导致python在执行`processing_reply`中把`data['message']`当作包含字典的列表，抛出错误`TypeError: string indices must be integers`并直接中断连接。

# 修复
- 在`config.json`中新增`Is_OneBot_Plugin`配置决定处理消息方法
- 在`processing_reply`增加try except结构防止抛出错误后立即中断连接
- 修复群发消息变量错误
