### PR TITLE
Feat: 更好的在群聊中使用命令 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -297,7 +297,9 @@ Muice-Chatbot     <- 主路径
     "Reply_Rate": 50,
     "At_Reply": false,
     "NonReply_Prefix": [],
-    "Voice_Reply_Rate": 0
+    "Voice_Reply_Rate": 0,
+    "Group_Cmd_For_Trusted_Users_Only": true,
+    "Group_Ignore_Cmd_Not_Found": true
 }
 ```
 
@@ -338,6 +340,10 @@ Muice-Chatbot     <- 主路径
 `NonReply_Prefix`: 消息前缀，机器人不会回复以这些前缀开头的消息。
 
 `Voice_Reply_Rate`: 语音回复的概率，取值范围为 0-100。
+
+`Group_Cmd_For_Trusted_Users_Only`: （群聊）只允许信任的人在群里使用命令
+
+`Group_Ignore_Cmd_Not_Found`: （群聊）当找不到命令时,是否**不**在群里发送: "没有当前命令"
 
 # 使用🎉
 

--- a/configs.json
+++ b/configs.json
@@ -32,5 +32,7 @@
     "NonReply_Prefix": [
         "#"
     ],
-    "Voice_Reply_Rate": 0
+    "Voice_Reply_Rate": 0,
+    "Group_Cmd_For_Trusted_Users_Only": true,
+    "Group_Ignore_Cmd_Not_Found": true
 }

--- a/configuration_gui.py
+++ b/configuration_gui.py
@@ -162,6 +162,20 @@ config_infomation = [
         "description": "机器人回复语音的概率。(设置为0则不回复语音)",
         "recommend": "50",
         "range": (0, 100)
+    },
+    {
+        "key": "Group_Ignore_Cmd_Not_Found",
+        "name": "群消息忽略命令未找到错误",
+        "type": "bool",
+        "description": "是否忽略用户在群内使用/找不到命令的提示。",
+        "recommend": "True"
+    },
+    {
+        "key": "Group_Cmd_For_Trusted_Users_Only",
+        "name": "仅允许可信用户在群使用命令",
+        "type": "bool",
+        "description": "若开启，机器人不会理会可信列表之外的人使用命令。",
+        "recommend": "True"
     }
 ]
 
@@ -187,7 +201,8 @@ Reply_Rate = 50
 At_Reply = False
 NonReply_Prefix = ["#"]
 Voice_Reply_Rate = 50
-
+Group_Cmd_For_Trusted_Users_Only = True
+Group_Ignore_Cmd_Not_Found = True
 
 def str_messagebox(index):
     """

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,7 +22,9 @@
     "Reply_Rate": 50,
     "At_Reply": false,
     "NonReply_Prefix": [],
-    "Voice_Reply_Rate": 0
+    "Voice_Reply_Rate": 0,
+    "Group_Cmd_For_Trusted_Users_Only": true,
+    "Group_Ignore_Cmd_Not_Found": true
 }
 ```
 
@@ -63,3 +65,7 @@
 `NonReply_Prefix`: 消息前缀，机器人不会回复以这些前缀开头的消息。
 
 `Voice_Reply_Rate`: 语音回复的概率，取值范围为 0-100。
+
+`Group_Cmd_For_Trusted_Users_Only`: （群聊）只允许信任的人在群里使用命令
+
+`Group_Ignore_Cmd_Not_Found`: （群聊）当找不到命令时,是否**不**在群里发送: "没有当前命令"

--- a/utils/Tools.py
+++ b/utils/Tools.py
@@ -45,7 +45,17 @@ def process_at_message(is_cq_code: bool, data) -> tuple[bool, list, str]:
         if at_qq_list and len(at_qq_list) > 0:
             return True, at_qq_list, message
         return False, at_qq_list, message
-    
+
+def is_command(message_raw: str) -> bool:
+    """
+    判断是否是命令。
+    Args:
+    - message_raw (str): 原始消息。
+    Returns:
+    - bool: 是否是命令。
+    """
+    return message_raw.strip().startswith('/')
+
 def is_reply_message(at_reply: bool, reply_rate: int, is_at_message: bool) -> bool:
     """
     判断是否是回复消息。

--- a/utils/command.py
+++ b/utils/command.py
@@ -69,12 +69,13 @@ class Command:
         return "cleaned"
 
     def reset(self) -> str:
-        if os.path.isfile(f'./memory/{self.Muice.user_qq}_backup.json'):
-            os.remove(f'./memory/{self.Muice.user_qq}_backup.json')
-        if not os.path.isfile(f'./memory/{self.Muice.user_qq}.json'):
+        memory_file = self.Muice.user_id
+        if os.path.isfile(f'./memory/{memory_file}_backup.json'):
+            os.remove(f'./memory/{memory_file}_backup.json')
+        if not os.path.isfile(f'./memory/{memory_file}.json'):
             return "你说得对，但是本雪和你没有说过一句话噢"
-        shutil.copy(f'./memory/{self.Muice.user_qq}.json', f'./memory/{self.Muice.user_qq}_backup.json')
-        os.remove(f'./memory/{self.Muice.user_qq}.json')
+        shutil.copy(f'./memory/{memory_file}.json', f'./memory/{memory_file}_backup.json')
+        os.remove(f'./memory/{memory_file}.json')
         self.Muice.history = []
         return "reseted"
 


### PR DESCRIPTION
修复我和小伙伴一起与沐雪深入交流时遇到的一点小问题！

# 事情是这样的
最开始我尝试在群聊内清除会话，但发现怎么操作都没有反应。
接着，我尝试在控制台输入reset命令，结果出现了错误。
之后，我开始浏览代码，发现对群聊命令的支持存在一些问题。
![image](https://github.com/user-attachments/assets/3e25ed97-adac-4cfa-ada0-2de8b165fd93)


# 更新内容
- 修复: 在控制台输入reset报错的问题
- 功能: 支持在群聊内使用命令

# 新增选项

`Group_Cmd_For_Trusted_Users_Only`: （群聊）只允许信任的人在群里使用命令

`Group_Ignore_Cmd_Not_Found`: （群聊）当找不到命令时,是否**不**在群里发送: "没有当前命令"